### PR TITLE
Updated fabric_api and wrapper to correctly show log level messages

### DIFF
--- a/dbt_wrapper/fabric_api.py
+++ b/dbt_wrapper/fabric_api.py
@@ -175,7 +175,7 @@ class FabricAPI:
     
     def APIUpsertNotebooks(self, progress: ProgressConsoleWrapper, task_id, dbt_project_dir, workspace_id, notebook_name=None):
         progress.progress.update(task_id=task_id, description="Logging in... Make sure you use `az login` to authenticate before running for the first time")
-        progress.print("Uploading notebooks via API ...", level=LogLevel.INFO)
+        progress.print("Starting notebooks validation and upload via API ...", level=LogLevel.INFO)
         target_dir = str(Path(dbt_project_dir) / Path("target"))
         notebooks_fabric_py_dir = os.getcwd() / Path(target_dir) / Path("notebooks_fabric_py")        
         fc = FabricClientCore(silent=True)
@@ -208,6 +208,11 @@ class FabricAPI:
                         notebook2 = fc.update_notebook_definition(workspace_id, notebookid, definition=notebook_w_content_new)
                         notebook3 = fc.update_item(workspace_id, notebookid, display_name=notebookname, description="Notebook Hash:" + notebookhashvalue)
                         progress.progress.update(task_id=task_id, description="Notebook updated " + notebookname)
+                    else:
+                        progress.print("Update to "  + notebookname + " is not required", level=LogLevel.INFO)
+
+        progress.print("Completed uploading notebooks via API", level=LogLevel.INFO)
+
         progress.progress.update(task_id=task_id, description="Completed uploading notebooks via API")
 
     def GetNotebookIdByName(self, workspace_id, notebook_name):

--- a/dbt_wrapper/fabric_api.py
+++ b/dbt_wrapper/fabric_api.py
@@ -203,13 +203,16 @@ class FabricAPI:
                 if notebookid == -1:
                     notebook = fc.create_notebook(workspace_id, definition=notebook_w_content_new, display_name=notebookname, description="Notebook Hash:" + notebookhashvalue)
                     progress.progress.update(task_id=task_id, description="Notebook created " + notebookname)
+                    progress.print("Notebook created " + notebookname, level=LogLevel.INFO)
+
                 else:
                     if notebookhashcheck == -1:
                         notebook2 = fc.update_notebook_definition(workspace_id, notebookid, definition=notebook_w_content_new)
                         notebook3 = fc.update_item(workspace_id, notebookid, display_name=notebookname, description="Notebook Hash:" + notebookhashvalue)
                         progress.progress.update(task_id=task_id, description="Notebook updated " + notebookname)
+                        progress.print("Notebook updated " + notebookname, level=LogLevel.INFO)
                     else:
-                        progress.print("Update to "  + notebookname + " is not required", level=LogLevel.INFO)
+                        progress.print("Update to " + notebookname + " is not required", level=LogLevel.INFO)
 
         progress.print("Completed uploading notebooks via API", level=LogLevel.INFO)
 

--- a/dbt_wrapper/wrapper.py
+++ b/dbt_wrapper/wrapper.py
@@ -160,7 +160,7 @@ class Commands:
     def RunMetadataExtract(self, progress: ProgressConsoleWrapper, task_id):
         nb_name = f"metadata_{self.project_name}_extract"
         nb_id = self.fa.GetNotebookIdByName(workspace_id=self.target_info['workspaceid'], notebook_name=nb_name)
-        if (1==1):
+        if nb_id is None:
             progress.print("Metadata Extract Notebook Not Found in Workspace. Uploading Notebook Now", level=LogLevel.INFO)
             self.fa.APIUpsertNotebooks(progress=progress, task_id=task_id, dbt_project_dir=self.dbt_project_dir, workspace_id=self.target_info['workspaceid'], notebook_name=nb_name)
         else: 


### PR DESCRIPTION
#168 

When running a dbt build with log-level=INFO the messages should not show that notebooks were not found. In addition to this messages were added when no action was taken on a notebook during the upload process.

![image](https://github.com/user-attachments/assets/0ae0d9df-0a7d-4e89-9d75-442610d517b7)
![image](https://github.com/user-attachments/assets/2fe38e2e-d97e-45aa-8552-5aa42a096abe)
