### PR TITLE
Updated stages to default hascheck to BYPASS and added build-local

### DIFF
--- a/.dbt-wrapper.yml
+++ b/.dbt-wrapper.yml
@@ -6,6 +6,7 @@ defaults:
   log_level: WARNING
   notebook_timeout: 1800
   lakehouse_config: METADATA
+  hashcheck_level: BYPASS
 
 # Environment-specific configurations
 environments:
@@ -34,7 +35,7 @@ workflows:
       - post-scripts
     options:
       log_level: INFO
-      hashcheck_level: WARNING
+  # hashcheck_level: WARNING
       upload_notebooks: false
       auto_run_master: false
   
@@ -53,7 +54,7 @@ workflows:
       - results
     options:
       log_level: WARNING
-      hashcheck_level: ERROR
+  # hashcheck_level: ERROR
       upload_notebooks: true
       auto_run_master: true
   
@@ -67,7 +68,7 @@ workflows:
       - validate
     options:
       log_level: INFO
-      hashcheck_level: ERROR
+  # hashcheck_level: ERROR
       notebook_timeout: 900
       upload_notebooks: false
       auto_run_master: false
@@ -88,7 +89,7 @@ workflows:
       - results
     options:
       log_level: ERROR
-      hashcheck_level: ERROR
+  # hashcheck_level: ERROR
       notebook_timeout: 3600
       upload_notebooks: true
       auto_run_master: true
@@ -101,7 +102,17 @@ workflows:
       - build
     options:
       log_level: DEBUG
-      hashcheck_level: BYPASS
+  # hashcheck_level: BYPASS
+  
+  # Build and post-scripts only (local build)
+  build-local:
+    description: Build and run post-scripts only (for local development)
+    stages:
+      - build
+      - post-scripts
+    options:
+      log_level: INFO
+  # hashcheck_level: WARNING
       
   # Metadata refresh only
   metadata-refresh:


### PR DESCRIPTION
This pull request updates the `.dbt-wrapper.yml` configuration to relax hash check enforcement across all environments and workflows, and introduces a new local build workflow. The main changes are grouped below:

**Hash Check Policy Relaxation:**

* The default `hashcheck_level` is now set to `BYPASS`, effectively disabling hash checks unless overridden.
* All explicit `hashcheck_level` settings in workflow `options` have been commented out, so workflows will now inherit the default bypass behavior. [[1]](diffhunk://#diff-d6be354c2ba0406cc6f01d3245d59017e10438dabcd2a2a77b509102e56ea345L37-R38) [[2]](diffhunk://#diff-d6be354c2ba0406cc6f01d3245d59017e10438dabcd2a2a77b509102e56ea345L56-R57) [[3]](diffhunk://#diff-d6be354c2ba0406cc6f01d3245d59017e10438dabcd2a2a77b509102e56ea345L70-R71) [[4]](diffhunk://#diff-d6be354c2ba0406cc6f01d3245d59017e10438dabcd2a2a77b509102e56ea345L91-R92) [[5]](diffhunk://#diff-d6be354c2ba0406cc6f01d3245d59017e10438dabcd2a2a77b509102e56ea345L104-R115)

**Workflow Enhancements:**

* Added a new `build-local` workflow for local development, which includes only the `build` and `post-scripts` stages with an `INFO` log level.